### PR TITLE
Ability to specify the host on which the exporter is accepting connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Based on [node-co2-monitor](https://github.com/huhamhire/node-co2-monitor).
 
 ## Supported Hardware
 
-* [TFA Dostmann AirCO2NTROL Mini - Monitor CO2 31.5006](https://www.amazon.de/dp/B00TH3OW4Q)
+* [TFA Dostmann AirCO2NTROL Mini - Monitor CO2 31.5006.02](https://www.amazon.de/dp/B00TH3OW4Q)
 
 
 ## Install
@@ -30,16 +30,17 @@ npm install co2-monitor-exporter -g
 
 
 ## Usage
+
 ```bash
-co2-exporter [--port <port>]
+co2-exporter [--port <port> --host <host>]
 ```
 
 Or starting with PM2 as a service.
 ```bash
-pm2 start `which co2-exporter` [-- --port <port>]
+pm2 start `which co2-exporter` [-- --port <port> --host <host>]
 ```
 
-After the exporter is started, prometheus server would be able to retrieve metric data from the exporter.
+By default the exporter will accept connections on `127.0.0.1:9091`. After the exporter is started, prometheus server would be able to retrieve metric data from the exporter.
 
 ![Grafana](https://huhamhire.github.io/co2-monitor-exporter/images/grafana.png)
 

--- a/exporter.js
+++ b/exporter.js
@@ -6,7 +6,8 @@ const CO2Monitor = require('node-co2-monitor');
 
 const argv = require('yargs').argv;
 const settings = {
-    port: argv.port || 9101
+    port: argv.port || 9101,
+    host: argv.host || '127.0.0.1'
 };
 
 // Initialize prometheus metrics.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "co2-monitor-exporter",
   "description": "Prometheus exporter for CO2 concentration and indoor temperature from TFA Dostmann AirCO2NTROL Mini.",
   "license": "MIT",
-  "version": "0.2.3",
+  "version": "0.2.4-dev",
   "author": {
     "name": "Hamhire Hu",
     "email": "me@huhamhire.com",


### PR DESCRIPTION
Adds the `--host <host>` option to the `co2-exporter` command with a default of `127.0.0.1`. This will stop the data being exposed to the internet.

If the host isn't specified for `server.listen` the server will listen to both `::` (IPv6) and possibly `0.0.0.0`, see https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback